### PR TITLE
chore: fix index schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mojaloop/reporting-events-processor-svc",
-  "version": "2.0.0",
+  "version": "3.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mojaloop/reporting-events-processor-svc",
-      "version": "2.0.0",
+      "version": "3.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@mojaloop/central-services-stream": "11.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/reporting-events-processor-svc",
-  "version": "3.1.0",
+  "version": "3.3.0",
   "description": "Event processor to store mojaloop kafka events to reporting events db",
   "author": "Mojaloop",
   "contributors": [

--- a/src/constants/json-schema.js
+++ b/src/constants/json-schema.js
@@ -101,14 +101,12 @@ const schema = {
           properties: {
             transactionId: {
               bsonType: 'string',
-              index:true
             },
             quoteId: {
               bsonType: 'string'
             },
             transferId: {
               bsonType: 'string',
-              index:true
             },
             settlementId: {
               bsonType: 'string'
@@ -121,7 +119,6 @@ const schema = {
             },
             eventType: {
               enum: ['Quote', 'Transfer', 'Settlement', 'FxQuote', 'FxTransfer'],
-              index:true
             }
           }
         }

--- a/src/utilities/mongodb-schema.js
+++ b/src/utilities/mongodb-schema.js
@@ -6,6 +6,11 @@ const createReportingSchema = async (client, colName) => {
       $jsonSchema: schema
     }
   })
+
+  // Create indexes for fields that require them
+  await client.db().collection(colName).createIndex({ 'metadata.reporting.transactionId': 1 })
+  await client.db().collection(colName).createIndex({ 'metadata.reporting.transferId': 1 })
+  await client.db().collection(colName).createIndex({ 'metadata.reporting.eventType': 1 })
 }
 
 const applySchema = async (client, colName) => {


### PR DESCRIPTION
The index keyword is not a standard part of the JSON Schema specification. It's also not a valid keyword within MongoDB's implementation of $jsonSchema for defining collection validation rules.

Need to create indexes seperately